### PR TITLE
Cacheable tipi deps

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,3 +1,8 @@
 {
-  "platform" : [ "Boost::+boost", "Boost::filesystem" ]
+  "tipi-deps/boost" : {
+      "@" : "v1.80.0-without-submodules"
+    , "u" : true
+    , "packages" : ["boost_system", "boost_filesystem", "boost_uuid"]
+    , "targets" : ["Boost::system", "Boost::filesystem", "Boost::uuid"]
+  }
 }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,7 +1,10 @@
 {
   "tipi-deps/boost" : {
-      "@" : "v1.80.0-without-submodules"
+    "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
+    , "@" : "v1.80.0-without-submodules"
     , "u" : true
+
+    , "opts" : "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)"
     , "packages" : ["boost_system", "boost_filesystem", "boost_uuid"]
     , "targets" : ["Boost::system", "Boost::filesystem", "Boost::uuid"]
   }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,11 +1,8 @@
 {
-  "tipi-deps/boost" : {
-    "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
-    , "@" : "v1.80.0-without-submodules"
-    , "u" : true
-
-    , "opts" : "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)"
-    , "packages" : ["boost_system", "boost_filesystem", "boost_uuid"]
-    , "targets" : ["Boost::system", "Boost::filesystem", "Boost::uuid"]
-  }
+  "boostorg/boost" : { "@" : "boost-1.80.0",
+    "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
+    "packages": [ "boost_system", "boost_filesystem", "boost_uuid" ],
+    "targets": [ "Boost::system", "Boost::filesystem", "Boost::uuid" ],
+    "u": true
+  }  
 }

--- a/.tipi/id
+++ b/.tipi/id
@@ -1,0 +1,1 @@
+{"host_name":"github.com","org_name":"cpp-pre","repo_name":"file"}

--- a/.tipi/opts
+++ b/.tipi/opts
@@ -1,0 +1,1 @@
+set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)

--- a/.tipi/opts
+++ b/.tipi/opts
@@ -1,1 +1,0 @@
-set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)


### PR DESCRIPTION
Changes to tipi deps file to build only with cacheable dependencies (no platform libs anymore)