### PR TITLE
FetchContentable cpp-pre::file - CMakeList in source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
         uses: actions/checkout@v2
       - name: tipi builds project 
         run: |
-          tipi . --dont-upgrade --verbose --test all --use-cmakelists
+          tipi . -t linux-cxx17 --dont-upgrade --verbose --test all --use-cmakelists

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
     name: build-linux
     runs-on: ubuntu-latest
     container: tipibuild/tipi-ubuntu
+    env:
+      TIPI_CACHE_FORCE_ENABLE: ON
+      CMAKE_TIPI_PROVIDER_ENABLE: ON
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,4 @@ jobs:
         uses: actions/checkout@v2
       - name: tipi builds project 
         run: |
-          export HOME=/root
-          mkdir -p ~/.tipi
           tipi . --dont-upgrade --verbose --test all --use-cmakelists

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: build 
+# This workflow is triggered on pushes to the repository.
+on: [push]
+
+jobs:
+  build: 
+    name: build-linux
+    runs-on: ubuntu-latest
+    container: tipibuild/tipi-ubuntu
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: tipi builds project 
+        run: |
+          export HOME=/root
+          mkdir -p ~/.tipi
+          tipi . --dont-upgrade --verbose --test all --use-cmakelists

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,8 +1,0 @@
-{
-  "boostorg/boost" : { "@" : "boost-1.80.0",
-    "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
-    "packages": [ "boost_system", "boost_filesystem", "boost_uuid" ],
-    "targets": [ "Boost::system", "Boost::filesystem", "Boost::uuid" ],
-    "u": true
-  }  
-}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ install(
 
 # Headers:
 install(
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    DIRECTORY pre
     DESTINATION "${include_install_dir}"
     FILES_MATCHING PATTERN "*.[ih]*"
     PATTERN build/ EXCLUDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ find_package(boost_uuid CONFIG REQUIRED)
 add_library(file INTERFACE )
 add_library(cpp-pre_file::file ALIAS file)
 
+set(include_install_dir "include")
+
 target_include_directories(file BEFORE INTERFACE 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> 
   $<INSTALL_INTERFACE:${include_install_dir}/>)
@@ -41,7 +43,6 @@ target_link_libraries(file INTERFACE
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-set(include_install_dir "include")
 
 # Targets:
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,48 +121,50 @@ install(
     DESTINATION "${config_install_dir}"
 )
 
+# This overcomes the issue with "cpp-pre_file::file depends on targets 
+# that are in no EXPORT sets in plain cmake non cmake-tipi-provider contexts
 set(BOOST_TARGETS boost_filesystem boost_system boost_uuid 
-boost_assert
-boost_atomic
-boost_config
-boost_container_hash
-boost_core
-boost_detail
-boost_io
-boost_iterator
-boost_move
-boost_numeric_conversion
-boost_predef
-boost_random
-boost_scope
-boost_smart_ptr
-boost_static_assert
-boost_throw_exception
-boost_tti
-boost_type_traits
-boost_variant2
-boost_winapi
-boost_align
-boost_array
-boost_concept_check
-boost_conversion
-boost_describe
-boost_dynamic_bitset
-boost_function_types
-boost_fusion
-boost_integer
-boost_mp11
-boost_mpl
-boost_optional
-boost_preprocessor
-boost_range
-boost_utility
-boost_tuple
-boost_typeof
-boost_functional
-boost_regex
-boost_function
-boost_bind
+  boost_assert
+  boost_atomic
+  boost_config
+  boost_container_hash
+  boost_core
+  boost_detail
+  boost_io
+  boost_iterator
+  boost_move
+  boost_numeric_conversion
+  boost_predef
+  boost_random
+  boost_scope
+  boost_smart_ptr
+  boost_static_assert
+  boost_throw_exception
+  boost_tti
+  boost_type_traits
+  boost_variant2
+  boost_winapi
+  boost_align
+  boost_array
+  boost_concept_check
+  boost_conversion
+  boost_describe
+  boost_dynamic_bitset
+  boost_function_types
+  boost_fusion
+  boost_integer
+  boost_mp11
+  boost_mpl
+  boost_optional
+  boost_preprocessor
+  boost_range
+  boost_utility
+  boost_tuple
+  boost_typeof
+  boost_functional
+  boost_regex
+  boost_function
+  boost_bind
 )
 install(
     TARGETS ${BOOST_TARGETS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-cmake_minimum_required(VERSION 3.17.0)
+cmake_minimum_required(VERSION 3.27.6)
 project(cpp-pre_file VERSION "0.0.1")
 
-# testing stuff
 enable_testing()
 
 # Warning as errors to ensure file quality
@@ -17,6 +16,7 @@ endif()
 
 find_package(Threads)
 
+include (FetchContent)
 FetchContent_Declare(
   Boost
   GIT_REPOSITORY https://github.com/boostorg/boost.git
@@ -120,6 +120,59 @@ install(
     FILES "${project_config}" "${version_config}"
     DESTINATION "${config_install_dir}"
 )
+
+set(BOOST_TARGETS boost_filesystem boost_system boost_uuid 
+boost_assert
+boost_atomic
+boost_config
+boost_container_hash
+boost_core
+boost_detail
+boost_io
+boost_iterator
+boost_move
+boost_numeric_conversion
+boost_predef
+boost_random
+boost_scope
+boost_smart_ptr
+boost_static_assert
+boost_throw_exception
+boost_tti
+boost_type_traits
+boost_variant2
+boost_winapi
+boost_align
+boost_array
+boost_concept_check
+boost_conversion
+boost_describe
+boost_dynamic_bitset
+boost_function_types
+boost_fusion
+boost_integer
+boost_mp11
+boost_mpl
+boost_optional
+boost_preprocessor
+boost_range
+boost_utility
+boost_tuple
+boost_typeof
+boost_functional
+boost_regex
+boost_function
+boost_bind
+)
+install(
+    TARGETS ${BOOST_TARGETS}
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
 install(
     EXPORT "${targets_export_name}"
     NAMESPACE "${namespace}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,127 @@
+cmake_minimum_required(VERSION 3.17.0)
+project(cpp-pre_file VERSION "0.0.1")
+
+# testing stuff
+enable_testing()
+
+# Warning as errors to ensure file quality
+string(TOUPPER "${CMAKE_CXX_COMPILER_ID}" COMPILER_IN_USE)
+if ("${COMPILER_IN_USE}" STREQUAL "GNU" OR "${COMPILER_IN_USE}" MATCHES "CLANG")
+	add_definitions(
+    -Wall
+		#-Werror
+		-Wno-unused-local-typedefs
+		-Wno-unused-variable
+  )
+endif()
+
+find_package(Threads)
+
+FetchContent_Declare(
+  Boost
+  GIT_REPOSITORY https://github.com/boostorg/boost.git
+  # boost 1.85
+  GIT_TAG         ab7968a0bbcf574a7859240d1d8443f58ed6f6cf
+)
+FetchContent_MakeAvailable(Boost)
+
+# Define library
+add_library(file INTERFACE )
+add_library(cpp-pre_file::file ALIAS file)
+
+target_include_directories(file BEFORE INTERFACE 
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> 
+  $<INSTALL_INTERFACE:${include_install_dir}/>)
+
+target_link_libraries(file INTERFACE 
+  Boost::system Boost::filesystem Boost::uuid 
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
+set(include_install_dir "include")
+
+# Targets:
+install(
+    TARGETS 
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+add_subdirectory(tests)
+
+
+# Installing
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/modules/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+
+# Targets:
+install(
+    TARGETS file 
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+install(
+    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    DESTINATION "${include_install_dir}"
+    FILES_MATCHING PATTERN "*.[ih]*"
+    PATTERN build/ EXCLUDE
+    PATTERN "/build*" EXCLUDE 
+    PATTERN ".git/*" EXCLUDE 
+    PATTERN ".tipistore/*" EXCLUDE 
+    PATTERN "doc/*" EXCLUDE 
+    PATTERN "node_modules/*" EXCLUDE 
+)
+
+# Config
+#   * <prefix>/lib/cmake/file/fileConfig.cmake
+#   * <prefix>/lib/cmake/file/fileConfigVersion.cmake
+#   * <prefix>/lib/cmake/file/fileTargets.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,13 @@ include (FetchContent)
 FetchContent_Declare(
   Boost
   GIT_REPOSITORY https://github.com/boostorg/boost.git
-  # boost 1.85
-  GIT_TAG         ab7968a0bbcf574a7859240d1d8443f58ed6f6cf
+  # boost 1.80
+  GIT_TAG         32da69a36f84c5255af8a994951918c258bac601
 )
 FetchContent_MakeAvailable(Boost)
+find_package(boost_filesystem CONFIG REQUIRED)
+find_package(boost_system CONFIG REQUIRED)
+find_package(boost_uuid CONFIG REQUIRED)
 
 # Define library
 add_library(file INTERFACE )
@@ -121,59 +124,59 @@ install(
     DESTINATION "${config_install_dir}"
 )
 
-# This overcomes the issue with "cpp-pre_file::file depends on targets 
-# that are in no EXPORT sets in plain cmake non cmake-tipi-provider contexts
-set(BOOST_TARGETS boost_filesystem boost_system boost_uuid 
-  boost_assert
-  boost_atomic
-  boost_config
-  boost_container_hash
-  boost_core
-  boost_detail
-  boost_io
-  boost_iterator
-  boost_move
-  boost_numeric_conversion
-  boost_predef
-  boost_random
-  boost_scope
-  boost_smart_ptr
-  boost_static_assert
-  boost_throw_exception
-  boost_tti
-  boost_type_traits
-  boost_variant2
-  boost_winapi
-  boost_align
-  boost_array
-  boost_concept_check
-  boost_conversion
-  boost_describe
-  boost_dynamic_bitset
-  boost_function_types
-  boost_fusion
-  boost_integer
-  boost_mp11
-  boost_mpl
-  boost_optional
-  boost_preprocessor
-  boost_range
-  boost_utility
-  boost_tuple
-  boost_typeof
-  boost_functional
-  boost_regex
-  boost_function
-  boost_bind
-)
-install(
-    TARGETS ${BOOST_TARGETS}
-    EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}"
-)
+## This overcomes the issue with "cpp-pre_file::file depends on targets 
+## that are in no EXPORT sets in plain cmake non cmake-tipi-provider contexts
+#set(BOOST_TARGETS boost_filesystem boost_system boost_uuid 
+#  boost_assert
+#  boost_atomic
+#  boost_config
+#  boost_container_hash
+#  boost_core
+#  boost_detail
+#  boost_io
+#  boost_iterator
+#  boost_move
+#  boost_numeric_conversion
+#  boost_predef
+#  boost_random
+#  boost_scope
+#  boost_smart_ptr
+#  boost_static_assert
+#  boost_throw_exception
+#  boost_tti
+#  boost_type_traits
+#  boost_variant2
+#  boost_winapi
+#  boost_align
+#  boost_array
+#  boost_concept_check
+#  boost_conversion
+#  boost_describe
+#  boost_dynamic_bitset
+#  boost_function_types
+#  boost_fusion
+#  boost_integer
+#  boost_mp11
+#  boost_mpl
+#  boost_optional
+#  boost_preprocessor
+#  boost_range
+#  boost_utility
+#  boost_tuple
+#  boost_typeof
+#  boost_functional
+#  boost_regex
+#  boost_function
+#  boost_bind
+#)
+#install(
+#    TARGETS ${BOOST_TARGETS}
+#    EXPORT "${targets_export_name}"
+#    LIBRARY DESTINATION "lib"
+#    ARCHIVE DESTINATION "lib"
+#    RUNTIME DESTINATION "bin"
+#    INCLUDES DESTINATION "${include_install_dir}"
+#)
 
 install(
     EXPORT "${targets_export_name}"

--- a/cmake/modules/Config.cmake.in
+++ b/cmake/modules/Config.cmake.in
@@ -1,0 +1,7 @@
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")
+
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# To modify this, edit the template:
+# - .tipi/CMakeLists.subdir-tests.txt.tpl
+# - tests/CMakeLists.subdir-tests.txt.tpl
+#
+# The templates can be generated using the 'tipi cmaketpl' command
+
+
+  # hash
+  add_executable(hash hash.cpp )
+  set_target_properties(hash PROPERTIES OUTPUT_NAME hash)
+  target_link_libraries(hash cpp-pre_file::file)
+
+  if (DEFINED EMSCRIPTEN)
+    add_test(NAME hash COMMAND node --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:hash>)
+  else() 
+    add_test(NAME hash COMMAND "$<TARGET_FILE:hash>")
+  endif()
+
+

--- a/tests/hash.cpp
+++ b/tests/hash.cpp
@@ -49,7 +49,7 @@ int main() {
     std::cout << "Modifying '" << testdata_path << "' & hashing again \n"
         << " - computed: " << hashed_modified << std::endl;
 
-    assert(hashed_modified == hashed_initial);
+    assert(hashed_modified != hashed_initial);
 
     std::cout << " [PASS]" << std::endl;
 


### PR DESCRIPTION
This provides the generated CMakeList from tipi in the source tree so that it can be used as FetchContent build.

The version used in the FetchContent calls are aligned with internal builds of nxxm/nxxm-src.